### PR TITLE
fix: repair back-office attribute routing broken by sf7.4 migration

### DIFF
--- a/Controller/ChronopostHomeDeliveryBackOfficeController.php
+++ b/Controller/ChronopostHomeDeliveryBackOfficeController.php
@@ -18,6 +18,7 @@ use Thelia\Model\LangQuery;
 
 /**
  */
+#[Route('/admin/module/ChronopostHomeDelivery/config', name: 'ChronopostHomeDelivery_config')]
 class ChronopostHomeDeliveryBackOfficeController extends BaseAdminController
 {
     /**
@@ -25,8 +26,8 @@ class ChronopostHomeDeliveryBackOfficeController extends BaseAdminController
      *
      * @return \Thelia\Core\HttpFoundation\Response
      */
-    #[Route('/admin/module/ChronopostHomeDelivery/config', name: 'ChronopostHomeDelivery_config')]
-    public function viewAction($tab)
+    #[Route('', name: '', methods: ['GET'])]
+    public function viewAction(string $tab = 'configure')
     {
         return $this->render(
             'module-configure',
@@ -42,7 +43,7 @@ class ChronopostHomeDeliveryBackOfficeController extends BaseAdminController
      *
      * @return mixed|null|\Symfony\Component\HttpFoundation\Response|\Thelia\Core\HttpFoundation\Response
      */
-    #[Route(', name=', name: '_save', methods: ['POST'])]
+    #[Route('', name: '_save', methods: ['POST'])]
     public function saveAction()
     {
         if (null !== $response = $this->checkAuth([AdminResources::MODULE], 'ChronopostHomeDelivery', AccessManager::UPDATE)) {

--- a/Controller/ChronopostHomeDeliveryFreeShippingController.php
+++ b/Controller/ChronopostHomeDeliveryFreeShippingController.php
@@ -18,15 +18,15 @@ use Symfony\Component\Routing\Attribute\Route;
 
 /**
  */
+#[Route('/admin/module/chronopost-home-delivery', name: 'chronopost-home-delivery')]
 class ChronopostHomeDeliveryFreeShippingController extends BaseAdminController
 {
     /**
      * Toggle free shipping for the delivery type being edited.
      *
      * @return mixed|null|Response|static
-     * @Route("/freeshipping", name="_freeshipping", methods="POST")
      */
-    #[Route('/admin/module/chronopost-home-delivery', name: 'chronopost-home-delivery')]
+    #[Route('/freeshipping', name: '_freeshipping', methods: ['POST'])]
     public function toggleFreeShippingActivation()
     {
         if (null !== $response = $this->checkAuth(array(AdminResources::MODULE), array('ChronopostHomeDelivery'), AccessManager::UPDATE)) {

--- a/Controller/ChronopostHomeDeliverySliceController.php
+++ b/Controller/ChronopostHomeDeliverySliceController.php
@@ -14,15 +14,15 @@ use Symfony\Component\Routing\Attribute\Route;
 
 /**
  */
+#[Route('/admin/module/chronopost-home-delivery/slice', name: 'chronopost-home-delivery_slice')]
 class ChronopostHomeDeliverySliceController extends BaseAdminController
 {
     /**
      * Save/Create a price slice in the delivery type being edited
      *
      * @return mixed|null|\Thelia\Core\HttpFoundation\Response
-     * @Route("/save", name="_save", methods="POST")
      */
-    #[Route('/admin/module/chronopost-home-delivery/slice', name: 'chronopost-home-delivery_slice')]
+    #[Route('/save', name: '_save', methods: ['POST'])]
     public function saveSliceAction(RequestStack $requestStack)
     {
         $response = $this->checkAuth([], ['chronopost'], AccessManager::UPDATE);


### PR DESCRIPTION
The migration to attribute routing left the controllers unreachable:
- viewAction($tab) had no route default for $tab, so saving the config page threw 'Could not resolve argument $tab ... viewaction()'
- saveAction route path was corrupted ('\, name=')
- method routes used relative paths with no class-level prefix, so the delivery-mode / freeshipping / slice form actions did not match.

Move the URL prefix to a class-level #[Route] (matching the existing TaxRuleController convention), give viewAction a GET method + default $tab, and restore the save/freeshipping route paths.